### PR TITLE
Get rid of RemovedInDjango41Warning

### DIFF
--- a/markdownfield/__init__.py
+++ b/markdownfield/__init__.py
@@ -1,5 +1,3 @@
 """A simple custom field for Django that can safely render Markdown and store it in the database.
 """
 __version__ = '0.10.0'
-
-default_app_config = 'markdownfield.apps.MarkdownFieldConfig'

--- a/markdownfield/__init__.py
+++ b/markdownfield/__init__.py
@@ -1,5 +1,3 @@
 """A simple custom field for Django that can safely render Markdown and store it in the database.
 """
 __version__ = '0.11.0'
-
-default_app_config = 'markdownfield.apps.MarkdownFieldConfig'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ author-email = "luke@dmptr.com"
 home-page = "https://github.com/dmptrluke/django-markdownfield"
 requires-python=">=3.6"
 requires = [
-    'django>=2.2',
+    'django>=3.2',
     'bleach',
     'markdown',
     'shortuuid',


### PR DESCRIPTION
Since Django 3.2, `default_app_config` wasn't needed. The slight problem is that 2.2 and 3.1 still need it (and are [still supported](https://www.djangoproject.com/download/))

So removing `default_app_config` means that projects in 2.2 and 3.1 have to specify the exact AppConfig path in `INSTALLED_APPS`.

It's a pickle. Perhaps not so interesting to address, but this was the first time that I stumbled upon it. I think that it's been deprecated to eagerly since reusable apps that want to support all currently supported Django versions will then either have to cut support or live with the deprecation warnings. Or maybe I'm missing something.

```
.virtualenvs/dukop/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'markdownfield' defines default_app_config = 'markdownfield.apps.MarkdownFieldConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```