### PR TITLE
Dark Mode Support

### DIFF
--- a/markdownfield/static/markdownfield/md_admin.css
+++ b/markdownfield/static/markdownfield/md_admin.css
@@ -12,6 +12,32 @@
     margin: 0 !important;
 }
 
+.EasyMDEContainer .editor-toolbar {
+    background-color: var(--primary);
+    border: none;
+}
+
+.EasyMDEContainer .editor-toolbar button {
+    color: var(--button-fg);
+    background-color: var(--button-bg);
+}
+
+.EasyMDEContainer .editor-toolbar button:hover,
+.EasyMDEContainer .editor-toolbar button.active {
+    border: none;
+    background-color: var(--button-hover-bg);
+}
+
+.EasyMDEContainer .CodeMirror {
+    color: var(--body-fg);
+    background-color: var(--body-bg);
+    border: 1px solid var(--border-color) !important;
+}
+
+.EasyMDEContainer .CodeMirror-cursor {
+    border-left: 1px solid var(--body-fg) !important;
+}
+
 .editor-preview {
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;


### PR DESCRIPTION
Django's admin has supported dark mode for quite some time. These changes use the admin's new theme css variables to get automatic color scheme support:

_Dark Mode_
![image](https://user-images.githubusercontent.com/4859329/216839862-dcb4b639-b0a5-4e91-8b6f-886c1a8c394d.png)

_Light Mode_
![image](https://user-images.githubusercontent.com/4859329/216842812-e0e44898-b874-4b68-9377-e9f181e31df9.png)

***

This might not be the best place in the code to put these style overrides, but this PR should at least get the discussion on using theme variables started.

For those who want to get dark mode support right away, you can add these changes to `<static>/css/admin/markdown_editor.css` and then add the following to any admin class in which you're using this editor:

```python
class ExampleAdmin(ModelAdmin):

    class Media:
        css = {"all": ["css/admin/markdown_editor.css"]}
```