### PR TITLE
Bump flit_core to 3.4 which supports build_editable / PEP 660

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=3.4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
I was getting this error with `pip install -e .`:

```
ERROR: Project file:///home/user/django-markdownfield has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.
```

`pip install -e` works after this change.

Not sure how these dependencies are normally managed.