### PR TITLE
Removed assumption of Settings.SITE_URL existing

### DIFF
--- a/markdownfield/util.py
+++ b/markdownfield/util.py
@@ -31,11 +31,17 @@ def format_link(attrs: Dict[tuple, str], new: bool = False):
         # the link isn't going anywhere, probably a fragment link
         return attrs
 
-    c = urlparse(settings.SITE_URL)
-    if p.netloc != c.netloc:
-        # link is external - secure and mark
-        attrs[(None, 'target')] = '_blank'
-        attrs[(None, 'class')] = attrs.get((None, 'class'), '') + ' external'
-        attrs[(None, 'rel')] = 'nofollow noopener noreferrer'
+    if hasattr(settings, 'SITE_URL'):
+        c = urlparse(settings.SITE_URL)
+        link_is_external = p.netloc != c.netloc
+    else:
+        # Assume true for safety
+        link_is_external = True
+
+    if link_is_external:
+            # link is external - secure and mark
+            attrs[(None, 'target')] = '_blank'
+            attrs[(None, 'class')] = attrs.get((None, 'class'), '') + ' external'
+            attrs[(None, 'rel')] = 'nofollow noopener noreferrer'
 
     return attrs

--- a/markdownfield/util.py
+++ b/markdownfield/util.py
@@ -39,9 +39,9 @@ def format_link(attrs: Dict[tuple, str], new: bool = False):
         link_is_external = True
 
     if link_is_external:
-            # link is external - secure and mark
-            attrs[(None, 'target')] = '_blank'
-            attrs[(None, 'class')] = attrs.get((None, 'class'), '') + ' external'
-            attrs[(None, 'rel')] = 'nofollow noopener noreferrer'
+        # link is external - secure and mark
+        attrs[(None, 'target')] = '_blank'
+        attrs[(None, 'class')] = attrs.get((None, 'class'), '') + ' external'
+        attrs[(None, 'rel')] = 'nofollow noopener noreferrer'
 
     return attrs


### PR DESCRIPTION
Not a standard Django setting, so causing crashes. Added a failsafe assumption of externality. This setting should be documented. If a dependency on the django-crequest package is fine, the request object would be available and could fetch the site URL in a standard way.