### PR TITLE
Add "extras" specifier to ensure tinycss2 is installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ home-page = "https://github.com/dmptrluke/django-markdownfield"
 requires-python=">=3.8"
 requires = [
     'django>=3.2',
-    'bleach',
+    'bleach[css]>=5.0.1',
     'markdown',
     'shortuuid',
     'dataclasses; python_version == "3.6"',


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/core/management/commands/runserver.py", line 110, in inner_run
    autoreload.raise_last_exception()
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/core/management/__init__.py", line 375, in execute
    autoreload.check_errors(django.setup)()
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/django/apps/config.py", line 301, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/django-dukop/src/dukop/apps/news/models.py", line 5, in <module>
    from markdownfield.models import MarkdownField
  File "/django-markdownfield/markdownfield/models.py", line 13, in <module>
    from .validators import VALIDATOR_STANDARD, Validator
  File "/django-markdownfield/markdownfield/validators.py", line 4, in <module>
    from bleach.css_sanitizer import CSSSanitizer
  File ".virtualenvs/django-dukop/lib/python3.10/site-packages/bleach/css_sanitizer.py", line 1, in <module>
    import tinycss2
ModuleNotFoundError: No module named 'tinycss2'
```