### PR TITLE
Fix field margin and fullscreen z-index

### DIFF
--- a/markdownfield/static/markdownfield/md_admin.css
+++ b/markdownfield/static/markdownfield/md_admin.css
@@ -1,15 +1,6 @@
-@media (min-width: 767px) {
-    .cm-s-easymde {
-        margin-left: 170px;
-    }
-
-    .editor-toolbar {
-        margin-left: 170px;
-    }
-}
-
 .cm-s-easymde.CodeMirror-fullscreen, .editor-toolbar.fullscreen {
     margin: 0 !important;
+    z-index: 20;
 }
 
 .EasyMDEContainer .editor-toolbar {


### PR DESCRIPTION
Probably needs to be tested in older versions of django to check compatability, but this fixes the ui in the latest django version.

The margin-left is no longer necessary, since the django admin frame seems to handle field responsiveness.

The z-index is necessary to get the fullscreen editor to appear above the sidebar.